### PR TITLE
Move Quarantine Role

### DIFF
--- a/TA-Illumio/default/authorize.conf
+++ b/TA-Illumio/default/authorize.conf
@@ -1,0 +1,3 @@
+## This capability determines if user can perform Quarantine Action on Illumio workload.
+[role_illumio_quarantine_workload]
+disabled = 0


### PR DESCRIPTION
The illumio_quarantine_workload role is required to run the illumio_quarantine action. Previously, the **authorize.conf** with the role definition was placed in the app, instead move it to the TA so it can be run manually without needing to install the app.

* move illumio_quarantine_workload role from app to TA